### PR TITLE
Fix the documentation link on the homepage

### DIFF
--- a/PageIndex.py
+++ b/PageIndex.py
@@ -101,7 +101,7 @@ class Sidebox (CTK.Container):
                     },
         'documentation': {
                         'icon': '/static/images/documentation.png',
-                        'url': '/doc',
+                        'url': '/doc/index.html',
                         'title': 'Read the Documentation',
                         'hint': 'Tutorials, recipes, etc'
                     },


### PR DESCRIPTION
Visiting [http://www.cherokee-project.com/doc](http://www.cherokee-project.com/doc) breaks all of the other links on the page.
